### PR TITLE
Added changeImage.py to convert .tiff to .jpeg and other required properties

### DIFF
--- a/changeImage.py
+++ b/changeImage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+from PIL import Image
+import os
+
+path = '/supplier-data/images'
+for filename in os.listdir(path):
+	if filename.endswith('.tiff'):
+		name = (filename.strip(".tiff")) + '.jpeg'
+		img = Image.open(os.path.join(path, filename))
+		img.resize((600,400)).convert('RGB').save("/supplier-data/images/{}".format(name))


### PR DESCRIPTION
changeImage.py achieves following:

- selects only images with extension .tiff
- converts images to .jpeg
- resizes to 600 x 400
- saves resulting file in the same folder as origin